### PR TITLE
Added C solution to 1.9 String Rotation

### DIFF
--- a/Ch 01. Arrays and Strings/9. String Rotation/Makefile
+++ b/Ch 01. Arrays and Strings/9. String Rotation/Makefile
@@ -20,5 +20,10 @@ check: main
 	./main waterbottle ATERBOTTLEW | grep 'False' > /dev/null
 	./main waterbottle aterbottlewa | grep 'False' > /dev/null
 	./main waterbottle waterbottlewaterbottle | grep 'False' > /dev/null
+	./main a a | grep 'False' > /dev/null
+	./main a aa | grep 'False' > /dev/null
+	./main aa aa | grep 'False' > /dev/null
+	./main aa aaa | grep 'False' > /dev/null
+	./main ab ba | grep 'True' > /dev/null
 
 .PHONY: clean check

--- a/Ch 01. Arrays and Strings/9. String Rotation/Makefile
+++ b/Ch 01. Arrays and Strings/9. String Rotation/Makefile
@@ -1,0 +1,24 @@
+main: main.c
+	gcc -o main main.c
+
+clean:
+	rm -vf main
+
+check: main
+	./main waterbottle waterbottle | grep 'False' > /dev/null
+	./main waterbottle aterbottlew | grep 'True' > /dev/null
+	./main waterbottle terbottlewa | grep 'True' > /dev/null
+	./main waterbottle erbottlewat | grep 'True' > /dev/null
+	./main waterbottle rbottlewate | grep 'True' > /dev/null
+	./main waterbottle bottlewater | grep 'True' > /dev/null
+	./main waterbottle ottlewaterb | grep 'True' > /dev/null
+	./main waterbottle ttlewaterbo | grep 'True' > /dev/null
+	./main waterbottle tlewaterbot | grep 'True' > /dev/null
+	./main waterbottle lewaterbott | grep 'True' > /dev/null
+	./main waterbottle ewaterbottl | grep 'True' > /dev/null
+	./main waterbottle aterbottlem | grep 'False' > /dev/null
+	./main waterbottle ATERBOTTLEW | grep 'False' > /dev/null
+	./main waterbottle aterbottlewa | grep 'False' > /dev/null
+	./main waterbottle waterbottlewaterbottle | grep 'False' > /dev/null
+
+.PHONY: clean check

--- a/Ch 01. Arrays and Strings/9. String Rotation/main.c
+++ b/Ch 01. Arrays and Strings/9. String Rotation/main.c
@@ -4,13 +4,15 @@
 
 static int isRotation(const char *a, const char *b)
 {
+	if (NULL == a || '\0' == *a || NULL == b || '\0' == *b)
+		return 0;
+
 	const int alen = strlen(a);
 	const int blen = strlen(b);
 
 	if (alen != blen)
 		return 0;
 
-	// should equal strings be considered a rotation on 0?
 	if (0 == strcmp(a, b))
 		return 0;
 

--- a/Ch 01. Arrays and Strings/9. String Rotation/main.c
+++ b/Ch 01. Arrays and Strings/9. String Rotation/main.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <strings.h>
+
+static int isRotation(const char *a, const char *b)
+{
+	const int alen = strlen(a);
+	const int blen = strlen(b);
+
+	if (alen != blen)
+		return 0;
+
+	// should equal strings be considered a rotation on 0?
+	if (0 == strcmp(a, b))
+		return 0;
+
+	char *buf = (char*) malloc(sizeof(char) * ((2 * alen) + 1));
+	memcpy(buf, b, blen);
+	memcpy(&buf[blen], b, blen + 1);
+
+	const char *c = strstr(buf, a); // our one call to 'substring'
+	free(buf);
+
+	return (NULL != c);
+}
+
+int main(const int argc, const char *argv[])
+{
+	if (argc != 3) {
+		fprintf(stderr, "usage: main string1 string2\n");
+		exit(1);
+	}
+
+	if (isRotation(argv[1], argv[2]))
+		printf("True\n");
+	else
+		printf("False\n");
+}

--- a/Ch 01. Arrays and Strings/9. String Rotation/main.c
+++ b/Ch 01. Arrays and Strings/9. String Rotation/main.c
@@ -14,7 +14,7 @@ static int isRotation(const char *a, const char *b)
 	if (0 == strcmp(a, b))
 		return 0;
 
-	char *buf = (char*) malloc(sizeof(char) * ((2 * alen) + 1));
+	char *buf = (char*) malloc(sizeof(char) * ((2 * blen) + 1));
 	memcpy(buf, b, blen);
 	memcpy(&buf[blen], b, blen + 1);
 


### PR DESCRIPTION
This solution compiles to main and accepts two string arguments. It will return `True` if the second string is a rotation of the first string. Equal strings are not treated as a rotation.

The `make check` build target runs a number of test cases and returns non-zero if any test does not give the expected result.

This solutions run in O(n) where n is equal to the length of the longest input string. 